### PR TITLE
Add OpenInfraMap to default tile sources

### DIFF
--- a/plugin/ui/dialogs.py
+++ b/plugin/ui/dialogs.py
@@ -80,6 +80,7 @@ class ConnectionsDialog(QDialog, Ui_DlgConnections):
     _MAPZEN = "Mapzen.com (default entry with credits)"
     _MAPCAT = "Mapcat.com (default entry with credits)"
     _NEXTZEN = "Nextzen.org (default entry with credits)"
+    _OIM = "OpenInfraMap.org"
 
     _predefined_tilejson_connections = {
         _OMT: {
@@ -112,6 +113,10 @@ class ConnectionsDialog(QDialog, Ui_DlgConnections):
             "url": "https://tile.nextzen.org/tilezen/vector/v1/512/all/tilejson.mvt.json?api_key={token}",
             "token": "80xAN5o0QuyFrcPVVIieTA",
         },
+        _OIM: {
+            "name": _OIM,
+            "url": "https://openinframap.org/map.json",
+        }
     }
 
     _CONNECTIONS_TAB = "selected_connections_tab"


### PR DESCRIPTION
Since I switched OpenInfraMap to vector tiles, every month someone asks me about a way to get this data into QGIS. This plugin seems pretty good!